### PR TITLE
Fix typo (double semicolons)

### DIFF
--- a/TangerineUI-purple.css
+++ b/TangerineUI-purple.css
@@ -2127,7 +2127,7 @@ body.layout-single-column  {
 .layout-single-column .list-panel .column-link span::before {
     left: -12px;
     top: -10px;
-    right: -12px;;
+    right: -12px;
     bottom: -10px;
 }
 .layout-single-column .column-link[href="/lists"].active:has(+ .list-panel .column-link.active) span::before {

--- a/TangerineUI.css
+++ b/TangerineUI.css
@@ -2127,7 +2127,7 @@ body.layout-single-column  {
 .layout-single-column .list-panel .column-link span::before {
     left: -12px;
     top: -10px;
-    right: -12px;;
+    right: -12px;
     bottom: -10px;
 }
 .layout-single-column .column-link[href="/lists"].active:has(+ .list-panel .column-link.active) span::before {

--- a/mastodon/app/javascript/styles/tangerineui-purple/layout-single-column.scss
+++ b/mastodon/app/javascript/styles/tangerineui-purple/layout-single-column.scss
@@ -2127,7 +2127,7 @@ body.layout-single-column  {
 .layout-single-column .list-panel .column-link span::before {
     left: -12px;
     top: -10px;
-    right: -12px;;
+    right: -12px;
     bottom: -10px;
 }
 .layout-single-column .column-link[href="/lists"].active:has(+ .list-panel .column-link.active) span::before {

--- a/mastodon/app/javascript/styles/tangerineui/layout-single-column.scss
+++ b/mastodon/app/javascript/styles/tangerineui/layout-single-column.scss
@@ -2127,7 +2127,7 @@ body.layout-single-column  {
 .layout-single-column .list-panel .column-link span::before {
     left: -12px;
     top: -10px;
-    right: -12px;;
+    right: -12px;
     bottom: -10px;
 }
 .layout-single-column .column-link[href="/lists"].active:has(+ .list-panel .column-link.active) span::before {


### PR DESCRIPTION
Just a typo fix: from `right: -12px;;` to `right: -12px;`.