### PR TITLE
Set background color for compose toolbar

### DIFF
--- a/TangerineUI-cherry.css
+++ b/TangerineUI-cherry.css
@@ -533,6 +533,11 @@ body.app-body  {
 .app-body .about__section__body {
     border: 0;
 }
+
+.app-body .compose-form .compose-form__buttons-wrapper {
+    background: var(--color-secondary-bg);
+}
+
 .app-body .column-inline-form,
 .app-body .column>.scrollable,
 .app-body .getting-started,

--- a/TangerineUI-purple.css
+++ b/TangerineUI-purple.css
@@ -533,6 +533,11 @@ body.app-body  {
 .app-body .about__section__body {
     border: 0;
 }
+
+.app-body .compose-form .compose-form__buttons-wrapper {
+    background: var(--color-secondary-bg);
+}
+
 .app-body .column-inline-form,
 .app-body .column>.scrollable,
 .app-body .getting-started,

--- a/TangerineUI.css
+++ b/TangerineUI.css
@@ -533,6 +533,11 @@ body.app-body  {
 .app-body .about__section__body {
     border: 0;
 }
+
+.app-body .compose-form .compose-form__buttons-wrapper {
+    background: var(--color-secondary-bg);
+}
+
 .app-body .column-inline-form,
 .app-body .column>.scrollable,
 .app-body .getting-started,


### PR DESCRIPTION
This fixes the hard to read compose window toolbar.

Before:
![image](https://github.com/user-attachments/assets/7b64901c-17a4-42b2-8d40-96ff9a44bedf)

After:
![image](https://github.com/user-attachments/assets/06ac52d3-ba72-438b-8731-eccaeb89157c)
