### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ This is a list of known Mastodon instances on which Tangerine UI has been instal
 | [asso.lgbt](https://asso.lgbt)                             | 5+             | the only theme      | Yes (Purple variant)    |
 | [Buddyverse.xyz](https://buddyverse.xyz)                   | 5+             | an optional theme   | No                      |
 | [isfeeling.social](https://isfeeling.social)               | 1+             | the only theme      | Yes (Purple variant)    |
-| [ucn.social](https://ucn.social)                           | 1+             | an optional theme   | Yes (Tangerine variant) |
 | [fedi.cyberwitches.club](https://fedi.cyberwitches.club)   | 1+             | the only theme      | Yes (Purple variant)    |
 | [mastodon.projetretro.io](https://mastodon.projetretro.io) | 1+             | an optional theme   | No                      |
 | [everythingbagel.social](https://everythingbagel.social)   | 1+             | an optional theme   | No                      |
 | [social.spicyweb.dev](https://social.spicyweb.dev)         | 1+             | the only theme      | Yes                     |
 | [e5n.cc](https://e5n.cc)                                   | 1+             | the only theme      | Yes (Lagoon)            |
 | [erica.moe](https://erica.moe)                             | 5+             | an optional theme   | Yes (Purple variant)    |
+| [henshaw.social](https://henshaw.social)                   | 1+             | the only theme      | Yes (Tangerine variant) |
 
 ## Compatibility
 ✅ [**Tangerine UI** (v2._x_)](https://github.com/nileane/TangerineUI-for-Mastodon/releases/latest) **is compatible with instances running Mastodon 4.3 and newer.**[^3]


### PR DESCRIPTION
Added henshaw.social to list of sites using Tangerine, and removed ucn.social because it's no longer online.