### PR TITLE
Patches to support Mastodon 4.5.0 beta (quote support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ This is a list of known Mastodon instances on which Tangerine UI has been instal
 | [social.lol](https://social.lol)                           | 850+           | an optional theme   | Yes (Tangerine variant) |
 | [tool.wales](https://toot.wales)                           | 650+           | an optional theme   | Yes (Tangerine variant) |
 | [shelter.moe](https://shelter.moe)                         | 300+           | an optional theme   | Yes (Tangerine variant) |
+| [thecanadian.social](https://thecanadian.social)           | 250+           | an optional theme   | No                      |
 | [vmst.io](https://vmst.io)                                 | 250+           | an optional theme   | No                      |
 | [mountains.social](https://mountains.social)               | 150+           | an optional theme   | No                      |
 | [tooter.social](https://tooter.social)                     | 150+           | an optional theme   | No                      |

--- a/TangerineUI-cherry.css
+++ b/TangerineUI-cherry.css
@@ -1791,6 +1791,9 @@ body.app-body  {
 .app-body .display-name {
     color: var(--color-content-fg);
 }
+.app-body .compose-form__uploads {
+    margin-bottom: 12px;
+}
 .app-body .compose-form__upload .icon-button.compose-form__upload__delete .icon {
     width: 15px;
     height: 15px;
@@ -1907,6 +1910,9 @@ body.app-body  {
 .app-body .upload-progress .icon {
     color: var(--color-accent)
 }
+.app-body .upload-progress__message {
+    margin-bottom: 20px;
+}
 .app-body .upload-progress__message,
 .app-body .upload-progress__message span {
     color: var(--color-content-fg);
@@ -1946,7 +1952,7 @@ body.app-body  {
     margin-top: 5px;
     padding-inline-start: 12px;
     gap: 6px;
-    margin-bottom: -10px;
+    margin-bottom: 12px;
 }
 .app-body .compose-form__poll__select__label {
     display: none;
@@ -2360,7 +2366,7 @@ body.app-body  {
 .app-body .status__prepend a bdi {
     font-weight: bold;
 }
-.app-body .status {
+.app-body .status:not(.compose-form .status) {
     margin-left: 56px;
     padding: 0 10px;
     border-bottom: 0;
@@ -2400,7 +2406,7 @@ body.app-body  {
 .app-body .dismissable-banner + .scrollable > div > article:first-child > div > .status__wrapper {
     border-top: 0;
 }
-.app-body .status__info {
+.app-body .status__info:not(.compose-form .status__info) {
     height: 22px;
     width: calc(100% + 56px);
     gap: 2px;
@@ -2410,20 +2416,20 @@ body.app-body  {
     line-height: 0.625;
     align-items: start;
 }
-.app-body .status__info .status__display-name {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name {
     overflow: visible;
     align-items: start;
     max-height: 22px;
 }
-.app-body .status__info .status__display-name .display-name bdi,
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name bdi,
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     vertical-align: top;
 }
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     display: inline;
     opacity: .6;
 }
-.app-body .status__relative-time {
+.app-body .status__relative-time:not(.compose-form .status__relative-time) {
     height: 22px;
     color: var(--color-content-fg);
     display: flex;
@@ -2475,7 +2481,7 @@ body.app-body  {
 .app-body .status__relative-time time + abbr {
     order: 2;
 }
-.app-body .status__avatar {
+.app-body .status__avatar:not(.compose-form .status__avatar) {
     margin-bottom: -10px;
     z-index: 2;
     border-radius: 50%;
@@ -3319,7 +3325,7 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 
 /* Quote posts */
-.app-body .status__quote {
+.app-body .status__quote:not(.compose-form .status__quote) {
     margin-inline-start: 0;
     border-radius: 10px;
     border: 1px solid var(--color-lines);
@@ -3341,23 +3347,23 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     border-radius: 10px;
     --color-post-bg: var(--color-content-secondary-bg);
 }
-.app-body .status--is-quote {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) {
     margin-inline-start: 0;
     padding: 0;
     overflow: hidden;
 }
-.app-body .status--is-quote .status__info {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info {
     margin-inline-start: 0;
     margin-block-end: 5px;
 }
-.app-body .status--is-quote .status__info .status__display-name {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info .status__display-name {
     gap: 6px;
 }
 .app-body .status--is-quote .account__avatar {
     width: 22px !important;
     height: 22px !important;
 }
-.app-body .status--is-quote .status__relative-time {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__relative-time {
     inset-inline-end: 10px;
 }
 
@@ -5649,7 +5655,8 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     }
 }
 .app-body .notification-group {
-    padding: 16px 23px;
+    padding: 16px 12px 16px 23px;
+    gap: 0;
 }
 .app-body .notification-group,
 .app-body .notification-ungrouped {
@@ -5723,6 +5730,13 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 .app-body .notification-group__main {
     overflow: unset;
+    padding: 0 10px;
+}
+@media screen and (max-width:770px) {
+    .app-body .notification-group__main {
+        overflow: unset;
+        padding: 0;
+    }
 }
 .app-body .notification-group__main__status {
     border: 1px solid var(--color-content-secondary-bg);
@@ -7483,6 +7497,15 @@ a:is(.active,
 .app-body .rules-list li:last-child {
     border-bottom: 0;
 }
+.app-body .about__section__body .rules-languages label {
+    color: var(--color-content-fg);
+}
+.app-body .about__section__body .rules-languages > select {
+    background: var(--color-accent-bg);
+    color: var(--color-content-fg);
+    border-color: var(--color-accent-lines);
+}
+
 .about__domain-blocks {
     background-color: var(--color-content-bg);
     border: 0;
@@ -8151,4 +8174,88 @@ a:is(.active,
 )::before {
     background-image: var(--icon-olympics);
     transform: scale(1.85);
+}
+
+/* Mastodon 4.5.0 fixes */
+.app-body .status--has-quote .status__content {
+  display: block;
+}
+.app-body .status__quote-author-button {
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+}
+.app-body .notification-ungrouped--quote .status--is-quote .status__avatar,
+.app-body .notification-ungrouped--quote .status--is-quote .account__avatar {
+  width: 16px !important;
+  height: 16px !important;
+}
+.app-body .notification-bar__action {
+  color: var(--color-accent);
+}
+.app-body .notification-bar__action:hover,
+.app-body .notification-bar__action:focus,
+.app-body .notification-bar__action:active
+{
+  background: var(--color-accent-bg);
+}
+.app-body .dialog-modal__header {
+  border-bottom-color: var(--color-lines);
+}
+.app-body .dialog-modal__content__description {
+  color: var(--color-content-fg);
+}
+.app-body .visibility-dropdown__button {
+  background: var(--color-accent-bg);
+  color: var(--color-content-fg);
+  border-color: var(--color-accent-lines);
+}
+.app-body .privacy-dropdown__dropdown,
+.app-body .language-dropdown__dropdown,
+.app-body .visibility-dropdown__dropdown {
+  background: var(--color-content-secondary-bg);
+  border-color: var(--color-content-secondary-separator);
+}
+.app-body .privacy-dropdown__option__content strong,
+.app-body .visibility-dropdown__option__content strong {
+  color: var(--color-content-fg-bold);
+}
+.app-body .privacy-dropdown__option__content,
+.app-body .visibility-dropdown__option__content {
+  color: var(--color-content-fg);
+}
+.app-body .privacy-dropdown__option:focus,
+.app-body .privacy-dropdown__option.active,
+.app-body .visibility-dropdown__option:focus,
+.app-body .visibility-dropdown__option.active {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+.app-body .privacy-dropdown__option:hover,
+.app-body .privacy-dropdown__option:active,
+.app-body .visibility-dropdown__option:hover,
+.app-body .visibility-dropdown__option:active {
+  background: var(--color-accent-focus);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-globe {
+  background-image: var(--icon-globe-visibility-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-unlock {
+  background-image: var(--icon-unlock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-lock {
+  background-image: var(--icon-lock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-at {
+  background-image: var(--icon-at-inv);
+}
+.app-body .compose-form .status__quote {
+  margin-bottom: 8px;
+  border-color: var(--color-accent-lines);
+}
+.app-body .compose-form .status__wrapper {
+  padding: 0;
+}
+.app-body .notification-ungrouped .status:not(.status--is-quote) {
+  border: 0;
+  padding: 0;
 }

--- a/TangerineUI-lagoon.css
+++ b/TangerineUI-lagoon.css
@@ -1791,6 +1791,9 @@ body.app-body  {
 .app-body .display-name {
     color: var(--color-content-fg);
 }
+.app-body .compose-form__uploads {
+    margin-bottom: 12px;
+}
 .app-body .compose-form__upload .icon-button.compose-form__upload__delete .icon {
     width: 15px;
     height: 15px;
@@ -1907,6 +1910,9 @@ body.app-body  {
 .app-body .upload-progress .icon {
     color: var(--color-accent)
 }
+.app-body .upload-progress__message {
+    margin-bottom: 20px;
+}
 .app-body .upload-progress__message,
 .app-body .upload-progress__message span {
     color: var(--color-content-fg);
@@ -1946,7 +1952,7 @@ body.app-body  {
     margin-top: 5px;
     padding-inline-start: 12px;
     gap: 6px;
-    margin-bottom: -10px;
+    margin-bottom: 12px;
 }
 .app-body .compose-form__poll__select__label {
     display: none;
@@ -2360,7 +2366,7 @@ body.app-body  {
 .app-body .status__prepend a bdi {
     font-weight: bold;
 }
-.app-body .status {
+.app-body .status:not(.compose-form .status) {
     margin-left: 56px;
     padding: 0 10px;
     border-bottom: 0;
@@ -2400,7 +2406,7 @@ body.app-body  {
 .app-body .dismissable-banner + .scrollable > div > article:first-child > div > .status__wrapper {
     border-top: 0;
 }
-.app-body .status__info {
+.app-body .status__info:not(.compose-form .status__info) {
     height: 22px;
     width: calc(100% + 56px);
     gap: 2px;
@@ -2410,20 +2416,20 @@ body.app-body  {
     line-height: 0.625;
     align-items: start;
 }
-.app-body .status__info .status__display-name {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name {
     overflow: visible;
     align-items: start;
     max-height: 22px;
 }
-.app-body .status__info .status__display-name .display-name bdi,
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name bdi,
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     vertical-align: top;
 }
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     display: inline;
     opacity: .6;
 }
-.app-body .status__relative-time {
+.app-body .status__relative-time:not(.compose-form .status__relative-time) {
     height: 22px;
     color: var(--color-content-fg);
     display: flex;
@@ -2475,7 +2481,7 @@ body.app-body  {
 .app-body .status__relative-time time + abbr {
     order: 2;
 }
-.app-body .status__avatar {
+.app-body .status__avatar:not(.compose-form .status__avatar) {
     margin-bottom: -10px;
     z-index: 2;
     border-radius: 50%;
@@ -3319,7 +3325,7 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 
 /* Quote posts */
-.app-body .status__quote {
+.app-body .status__quote:not(.compose-form .status__quote) {
     margin-inline-start: 0;
     border-radius: 10px;
     border: 1px solid var(--color-lines);
@@ -3341,23 +3347,23 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     border-radius: 10px;
     --color-post-bg: var(--color-content-secondary-bg);
 }
-.app-body .status--is-quote {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) {
     margin-inline-start: 0;
     padding: 0;
     overflow: hidden;
 }
-.app-body .status--is-quote .status__info {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info {
     margin-inline-start: 0;
     margin-block-end: 5px;
 }
-.app-body .status--is-quote .status__info .status__display-name {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info .status__display-name {
     gap: 6px;
 }
 .app-body .status--is-quote .account__avatar {
     width: 22px !important;
     height: 22px !important;
 }
-.app-body .status--is-quote .status__relative-time {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__relative-time {
     inset-inline-end: 10px;
 }
 
@@ -5649,7 +5655,8 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     }
 }
 .app-body .notification-group {
-    padding: 16px 23px;
+    padding: 16px 12px 16px 23px;
+    gap: 0;
 }
 .app-body .notification-group,
 .app-body .notification-ungrouped {
@@ -5723,6 +5730,13 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 .app-body .notification-group__main {
     overflow: unset;
+    padding: 0 10px;
+}
+@media screen and (max-width:770px) {
+    .app-body .notification-group__main {
+        overflow: unset;
+        padding: 0;
+    }
 }
 .app-body .notification-group__main__status {
     border: 1px solid var(--color-content-secondary-bg);
@@ -7483,6 +7497,15 @@ a:is(.active,
 .app-body .rules-list li:last-child {
     border-bottom: 0;
 }
+.app-body .about__section__body .rules-languages label {
+    color: var(--color-content-fg);
+}
+.app-body .about__section__body .rules-languages > select {
+    background: var(--color-accent-bg);
+    color: var(--color-content-fg);
+    border-color: var(--color-accent-lines);
+}
+
 .about__domain-blocks {
     background-color: var(--color-content-bg);
     border: 0;
@@ -8151,4 +8174,88 @@ a:is(.active,
 )::before {
     background-image: var(--icon-olympics);
     transform: scale(1.85);
+}
+
+/* Mastodon 4.5.0 fixes */
+.app-body .status--has-quote .status__content {
+  display: block;
+}
+.app-body .status__quote-author-button {
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+}
+.app-body .notification-ungrouped--quote .status--is-quote .status__avatar,
+.app-body .notification-ungrouped--quote .status--is-quote .account__avatar {
+  width: 16px !important;
+  height: 16px !important;
+}
+.app-body .notification-bar__action {
+  color: var(--color-accent);
+}
+.app-body .notification-bar__action:hover,
+.app-body .notification-bar__action:focus,
+.app-body .notification-bar__action:active
+{
+  background: var(--color-accent-bg);
+}
+.app-body .dialog-modal__header {
+  border-bottom-color: var(--color-lines);
+}
+.app-body .dialog-modal__content__description {
+  color: var(--color-content-fg);
+}
+.app-body .visibility-dropdown__button {
+  background: var(--color-accent-bg);
+  color: var(--color-content-fg);
+  border-color: var(--color-accent-lines);
+}
+.app-body .privacy-dropdown__dropdown,
+.app-body .language-dropdown__dropdown,
+.app-body .visibility-dropdown__dropdown {
+  background: var(--color-content-secondary-bg);
+  border-color: var(--color-content-secondary-separator);
+}
+.app-body .privacy-dropdown__option__content strong,
+.app-body .visibility-dropdown__option__content strong {
+  color: var(--color-content-fg-bold);
+}
+.app-body .privacy-dropdown__option__content,
+.app-body .visibility-dropdown__option__content {
+  color: var(--color-content-fg);
+}
+.app-body .privacy-dropdown__option:focus,
+.app-body .privacy-dropdown__option.active,
+.app-body .visibility-dropdown__option:focus,
+.app-body .visibility-dropdown__option.active {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+.app-body .privacy-dropdown__option:hover,
+.app-body .privacy-dropdown__option:active,
+.app-body .visibility-dropdown__option:hover,
+.app-body .visibility-dropdown__option:active {
+  background: var(--color-accent-focus);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-globe {
+  background-image: var(--icon-globe-visibility-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-unlock {
+  background-image: var(--icon-unlock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-lock {
+  background-image: var(--icon-lock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-at {
+  background-image: var(--icon-at-inv);
+}
+.app-body .compose-form .status__quote {
+  margin-bottom: 8px;
+  border-color: var(--color-accent-lines);
+}
+.app-body .compose-form .status__wrapper {
+  padding: 0;
+}
+.app-body .notification-ungrouped .status:not(.status--is-quote) {
+  border: 0;
+  padding: 0;
 }

--- a/TangerineUI-purple.css
+++ b/TangerineUI-purple.css
@@ -1791,6 +1791,9 @@ body.app-body  {
 .app-body .display-name {
     color: var(--color-content-fg);
 }
+.app-body .compose-form__uploads {
+    margin-bottom: 12px;
+}
 .app-body .compose-form__upload .icon-button.compose-form__upload__delete .icon {
     width: 15px;
     height: 15px;
@@ -1907,6 +1910,9 @@ body.app-body  {
 .app-body .upload-progress .icon {
     color: var(--color-accent)
 }
+.app-body .upload-progress__message {
+    margin-bottom: 20px;
+}
 .app-body .upload-progress__message,
 .app-body .upload-progress__message span {
     color: var(--color-content-fg);
@@ -1946,7 +1952,7 @@ body.app-body  {
     margin-top: 5px;
     padding-inline-start: 12px;
     gap: 6px;
-    margin-bottom: -10px;
+    margin-bottom: 12px;
 }
 .app-body .compose-form__poll__select__label {
     display: none;
@@ -2360,7 +2366,7 @@ body.app-body  {
 .app-body .status__prepend a bdi {
     font-weight: bold;
 }
-.app-body .status {
+.app-body .status:not(.compose-form .status) {
     margin-left: 56px;
     padding: 0 10px;
     border-bottom: 0;
@@ -2400,7 +2406,7 @@ body.app-body  {
 .app-body .dismissable-banner + .scrollable > div > article:first-child > div > .status__wrapper {
     border-top: 0;
 }
-.app-body .status__info {
+.app-body .status__info:not(.compose-form .status__info) {
     height: 22px;
     width: calc(100% + 56px);
     gap: 2px;
@@ -2410,20 +2416,20 @@ body.app-body  {
     line-height: 0.625;
     align-items: start;
 }
-.app-body .status__info .status__display-name {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name {
     overflow: visible;
     align-items: start;
     max-height: 22px;
 }
-.app-body .status__info .status__display-name .display-name bdi,
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name bdi,
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     vertical-align: top;
 }
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     display: inline;
     opacity: .6;
 }
-.app-body .status__relative-time {
+.app-body .status__relative-time:not(.compose-form .status__relative-time) {
     height: 22px;
     color: var(--color-content-fg);
     display: flex;
@@ -2475,7 +2481,7 @@ body.app-body  {
 .app-body .status__relative-time time + abbr {
     order: 2;
 }
-.app-body .status__avatar {
+.app-body .status__avatar:not(.compose-form .status__avatar) {
     margin-bottom: -10px;
     z-index: 2;
     border-radius: 50%;
@@ -3319,7 +3325,7 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 
 /* Quote posts */
-.app-body .status__quote {
+.app-body .status__quote:not(.compose-form .status__quote) {
     margin-inline-start: 0;
     border-radius: 10px;
     border: 1px solid var(--color-lines);
@@ -3341,23 +3347,23 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     border-radius: 10px;
     --color-post-bg: var(--color-content-secondary-bg);
 }
-.app-body .status--is-quote {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) {
     margin-inline-start: 0;
     padding: 0;
     overflow: hidden;
 }
-.app-body .status--is-quote .status__info {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info {
     margin-inline-start: 0;
     margin-block-end: 5px;
 }
-.app-body .status--is-quote .status__info .status__display-name {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info .status__display-name {
     gap: 6px;
 }
 .app-body .status--is-quote .account__avatar {
     width: 22px !important;
     height: 22px !important;
 }
-.app-body .status--is-quote .status__relative-time {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__relative-time {
     inset-inline-end: 10px;
 }
 
@@ -5649,7 +5655,8 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     }
 }
 .app-body .notification-group {
-    padding: 16px 23px;
+    padding: 16px 12px 16px 23px;
+    gap: 0;
 }
 .app-body .notification-group,
 .app-body .notification-ungrouped {
@@ -5723,6 +5730,13 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 .app-body .notification-group__main {
     overflow: unset;
+    padding: 0 10px;
+}
+@media screen and (max-width:770px) {
+    .app-body .notification-group__main {
+        overflow: unset;
+        padding: 0;
+    }
 }
 .app-body .notification-group__main__status {
     border: 1px solid var(--color-content-secondary-bg);
@@ -7483,6 +7497,15 @@ a:is(.active,
 .app-body .rules-list li:last-child {
     border-bottom: 0;
 }
+.app-body .about__section__body .rules-languages label {
+    color: var(--color-content-fg);
+}
+.app-body .about__section__body .rules-languages > select {
+    background: var(--color-accent-bg);
+    color: var(--color-content-fg);
+    border-color: var(--color-accent-lines);
+}
+
 .about__domain-blocks {
     background-color: var(--color-content-bg);
     border: 0;
@@ -8151,4 +8174,88 @@ a:is(.active,
 )::before {
     background-image: var(--icon-olympics);
     transform: scale(1.85);
+}
+
+/* Mastodon 4.5.0 fixes */
+.app-body .status--has-quote .status__content {
+  display: block;
+}
+.app-body .status__quote-author-button {
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+}
+.app-body .notification-ungrouped--quote .status--is-quote .status__avatar,
+.app-body .notification-ungrouped--quote .status--is-quote .account__avatar {
+  width: 16px !important;
+  height: 16px !important;
+}
+.app-body .notification-bar__action {
+  color: var(--color-accent);
+}
+.app-body .notification-bar__action:hover,
+.app-body .notification-bar__action:focus,
+.app-body .notification-bar__action:active
+{
+  background: var(--color-accent-bg);
+}
+.app-body .dialog-modal__header {
+  border-bottom-color: var(--color-lines);
+}
+.app-body .dialog-modal__content__description {
+  color: var(--color-content-fg);
+}
+.app-body .visibility-dropdown__button {
+  background: var(--color-accent-bg);
+  color: var(--color-content-fg);
+  border-color: var(--color-accent-lines);
+}
+.app-body .privacy-dropdown__dropdown,
+.app-body .language-dropdown__dropdown,
+.app-body .visibility-dropdown__dropdown {
+  background: var(--color-content-secondary-bg);
+  border-color: var(--color-content-secondary-separator);
+}
+.app-body .privacy-dropdown__option__content strong,
+.app-body .visibility-dropdown__option__content strong {
+  color: var(--color-content-fg-bold);
+}
+.app-body .privacy-dropdown__option__content,
+.app-body .visibility-dropdown__option__content {
+  color: var(--color-content-fg);
+}
+.app-body .privacy-dropdown__option:focus,
+.app-body .privacy-dropdown__option.active,
+.app-body .visibility-dropdown__option:focus,
+.app-body .visibility-dropdown__option.active {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+.app-body .privacy-dropdown__option:hover,
+.app-body .privacy-dropdown__option:active,
+.app-body .visibility-dropdown__option:hover,
+.app-body .visibility-dropdown__option:active {
+  background: var(--color-accent-focus);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-globe {
+  background-image: var(--icon-globe-visibility-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-unlock {
+  background-image: var(--icon-unlock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-lock {
+  background-image: var(--icon-lock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-at {
+  background-image: var(--icon-at-inv);
+}
+.app-body .compose-form .status__quote {
+  margin-bottom: 8px;
+  border-color: var(--color-accent-lines);
+}
+.app-body .compose-form .status__wrapper {
+  padding: 0;
+}
+.app-body .notification-ungrouped .status:not(.status--is-quote) {
+  border: 0;
+  padding: 0;
 }

--- a/TangerineUI.css
+++ b/TangerineUI.css
@@ -1791,6 +1791,9 @@ body.app-body  {
 .app-body .display-name {
     color: var(--color-content-fg);
 }
+.app-body .compose-form__uploads {
+    margin-bottom: 12px;
+}
 .app-body .compose-form__upload .icon-button.compose-form__upload__delete .icon {
     width: 15px;
     height: 15px;
@@ -1907,6 +1910,9 @@ body.app-body  {
 .app-body .upload-progress .icon {
     color: var(--color-accent)
 }
+.app-body .upload-progress__message {
+    margin-bottom: 20px;
+}
 .app-body .upload-progress__message,
 .app-body .upload-progress__message span {
     color: var(--color-content-fg);
@@ -1946,7 +1952,7 @@ body.app-body  {
     margin-top: 5px;
     padding-inline-start: 12px;
     gap: 6px;
-    margin-bottom: -10px;
+    margin-bottom: 12px;
 }
 .app-body .compose-form__poll__select__label {
     display: none;
@@ -2360,7 +2366,7 @@ body.app-body  {
 .app-body .status__prepend a bdi {
     font-weight: bold;
 }
-.app-body .status {
+.app-body .status:not(.compose-form .status) {
     margin-left: 56px;
     padding: 0 10px;
     border-bottom: 0;
@@ -2400,7 +2406,7 @@ body.app-body  {
 .app-body .dismissable-banner + .scrollable > div > article:first-child > div > .status__wrapper {
     border-top: 0;
 }
-.app-body .status__info {
+.app-body .status__info:not(.compose-form .status__info) {
     height: 22px;
     width: calc(100% + 56px);
     gap: 2px;
@@ -2410,20 +2416,20 @@ body.app-body  {
     line-height: 0.625;
     align-items: start;
 }
-.app-body .status__info .status__display-name {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name {
     overflow: visible;
     align-items: start;
     max-height: 22px;
 }
-.app-body .status__info .status__display-name .display-name bdi,
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name bdi,
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     vertical-align: top;
 }
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     display: inline;
     opacity: .6;
 }
-.app-body .status__relative-time {
+.app-body .status__relative-time:not(.compose-form .status__relative-time) {
     height: 22px;
     color: var(--color-content-fg);
     display: flex;
@@ -2475,7 +2481,7 @@ body.app-body  {
 .app-body .status__relative-time time + abbr {
     order: 2;
 }
-.app-body .status__avatar {
+.app-body .status__avatar:not(.compose-form .status__avatar) {
     margin-bottom: -10px;
     z-index: 2;
     border-radius: 50%;
@@ -3319,7 +3325,7 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 
 /* Quote posts */
-.app-body .status__quote {
+.app-body .status__quote:not(.compose-form .status__quote) {
     margin-inline-start: 0;
     border-radius: 10px;
     border: 1px solid var(--color-lines);
@@ -3341,23 +3347,23 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     border-radius: 10px;
     --color-post-bg: var(--color-content-secondary-bg);
 }
-.app-body .status--is-quote {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) {
     margin-inline-start: 0;
     padding: 0;
     overflow: hidden;
 }
-.app-body .status--is-quote .status__info {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info {
     margin-inline-start: 0;
     margin-block-end: 5px;
 }
-.app-body .status--is-quote .status__info .status__display-name {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info .status__display-name {
     gap: 6px;
 }
 .app-body .status--is-quote .account__avatar {
     width: 22px !important;
     height: 22px !important;
 }
-.app-body .status--is-quote .status__relative-time {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__relative-time {
     inset-inline-end: 10px;
 }
 
@@ -5649,7 +5655,8 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     }
 }
 .app-body .notification-group {
-    padding: 16px 23px;
+    padding: 16px 12px 16px 23px;
+    gap: 0;
 }
 .app-body .notification-group,
 .app-body .notification-ungrouped {
@@ -5723,6 +5730,13 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 .app-body .notification-group__main {
     overflow: unset;
+    padding: 0 10px;
+}
+@media screen and (max-width:770px) {
+    .app-body .notification-group__main {
+        overflow: unset;
+        padding: 0;
+    }
 }
 .app-body .notification-group__main__status {
     border: 1px solid var(--color-content-secondary-bg);
@@ -7483,6 +7497,15 @@ a:is(.active,
 .app-body .rules-list li:last-child {
     border-bottom: 0;
 }
+.app-body .about__section__body .rules-languages label {
+    color: var(--color-content-fg);
+}
+.app-body .about__section__body .rules-languages > select {
+    background: var(--color-accent-bg);
+    color: var(--color-content-fg);
+    border-color: var(--color-accent-lines);
+}
+
 .about__domain-blocks {
     background-color: var(--color-content-bg);
     border: 0;
@@ -8151,4 +8174,88 @@ a:is(.active,
 )::before {
     background-image: var(--icon-olympics);
     transform: scale(1.85);
+}
+
+/* Mastodon 4.5.0 fixes */
+.app-body .status--has-quote .status__content {
+  display: block;
+}
+.app-body .status__quote-author-button {
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+}
+.app-body .notification-ungrouped--quote .status--is-quote .status__avatar,
+.app-body .notification-ungrouped--quote .status--is-quote .account__avatar {
+  width: 16px !important;
+  height: 16px !important;
+}
+.app-body .notification-bar__action {
+  color: var(--color-accent);
+}
+.app-body .notification-bar__action:hover,
+.app-body .notification-bar__action:focus,
+.app-body .notification-bar__action:active
+{
+  background: var(--color-accent-bg);
+}
+.app-body .dialog-modal__header {
+  border-bottom-color: var(--color-lines);
+}
+.app-body .dialog-modal__content__description {
+  color: var(--color-content-fg);
+}
+.app-body .visibility-dropdown__button {
+  background: var(--color-accent-bg);
+  color: var(--color-content-fg);
+  border-color: var(--color-accent-lines);
+}
+.app-body .privacy-dropdown__dropdown,
+.app-body .language-dropdown__dropdown,
+.app-body .visibility-dropdown__dropdown {
+  background: var(--color-content-secondary-bg);
+  border-color: var(--color-content-secondary-separator);
+}
+.app-body .privacy-dropdown__option__content strong,
+.app-body .visibility-dropdown__option__content strong {
+  color: var(--color-content-fg-bold);
+}
+.app-body .privacy-dropdown__option__content,
+.app-body .visibility-dropdown__option__content {
+  color: var(--color-content-fg);
+}
+.app-body .privacy-dropdown__option:focus,
+.app-body .privacy-dropdown__option.active,
+.app-body .visibility-dropdown__option:focus,
+.app-body .visibility-dropdown__option.active {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+.app-body .privacy-dropdown__option:hover,
+.app-body .privacy-dropdown__option:active,
+.app-body .visibility-dropdown__option:hover,
+.app-body .visibility-dropdown__option:active {
+  background: var(--color-accent-focus);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-globe {
+  background-image: var(--icon-globe-visibility-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-unlock {
+  background-image: var(--icon-unlock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-lock {
+  background-image: var(--icon-lock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-at {
+  background-image: var(--icon-at-inv);
+}
+.app-body .compose-form .status__quote {
+  margin-bottom: 8px;
+  border-color: var(--color-accent-lines);
+}
+.app-body .compose-form .status__wrapper {
+  padding: 0;
+}
+.app-body .notification-ungrouped .status:not(.status--is-quote) {
+  border: 0;
+  padding: 0;
 }

--- a/mastodon/app/javascript/styles/tangerineui-cherry/tangerineui-cherry.scss
+++ b/mastodon/app/javascript/styles/tangerineui-cherry/tangerineui-cherry.scss
@@ -1791,6 +1791,9 @@ body.app-body  {
 .app-body .display-name {
     color: var(--color-content-fg);
 }
+.app-body .compose-form__uploads {
+    margin-bottom: 12px;
+}
 .app-body .compose-form__upload .icon-button.compose-form__upload__delete .icon {
     width: 15px;
     height: 15px;
@@ -1907,6 +1910,9 @@ body.app-body  {
 .app-body .upload-progress .icon {
     color: var(--color-accent)
 }
+.app-body .upload-progress__message {
+    margin-bottom: 20px;
+}
 .app-body .upload-progress__message,
 .app-body .upload-progress__message span {
     color: var(--color-content-fg);
@@ -1946,7 +1952,7 @@ body.app-body  {
     margin-top: 5px;
     padding-inline-start: 12px;
     gap: 6px;
-    margin-bottom: -10px;
+    margin-bottom: 12px;
 }
 .app-body .compose-form__poll__select__label {
     display: none;
@@ -2360,7 +2366,7 @@ body.app-body  {
 .app-body .status__prepend a bdi {
     font-weight: bold;
 }
-.app-body .status {
+.app-body .status:not(.compose-form .status) {
     margin-left: 56px;
     padding: 0 10px;
     border-bottom: 0;
@@ -2400,7 +2406,7 @@ body.app-body  {
 .app-body .dismissable-banner + .scrollable > div > article:first-child > div > .status__wrapper {
     border-top: 0;
 }
-.app-body .status__info {
+.app-body .status__info:not(.compose-form .status__info) {
     height: 22px;
     width: calc(100% + 56px);
     gap: 2px;
@@ -2410,20 +2416,20 @@ body.app-body  {
     line-height: 0.625;
     align-items: start;
 }
-.app-body .status__info .status__display-name {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name {
     overflow: visible;
     align-items: start;
     max-height: 22px;
 }
-.app-body .status__info .status__display-name .display-name bdi,
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name bdi,
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     vertical-align: top;
 }
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     display: inline;
     opacity: .6;
 }
-.app-body .status__relative-time {
+.app-body .status__relative-time:not(.compose-form .status__relative-time) {
     height: 22px;
     color: var(--color-content-fg);
     display: flex;
@@ -2475,7 +2481,7 @@ body.app-body  {
 .app-body .status__relative-time time + abbr {
     order: 2;
 }
-.app-body .status__avatar {
+.app-body .status__avatar:not(.compose-form .status__avatar) {
     margin-bottom: -10px;
     z-index: 2;
     border-radius: 50%;
@@ -3319,7 +3325,7 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 
 /* Quote posts */
-.app-body .status__quote {
+.app-body .status__quote:not(.compose-form .status__quote) {
     margin-inline-start: 0;
     border-radius: 10px;
     border: 1px solid var(--color-lines);
@@ -3341,23 +3347,23 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     border-radius: 10px;
     --color-post-bg: var(--color-content-secondary-bg);
 }
-.app-body .status--is-quote {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) {
     margin-inline-start: 0;
     padding: 0;
     overflow: hidden;
 }
-.app-body .status--is-quote .status__info {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info {
     margin-inline-start: 0;
     margin-block-end: 5px;
 }
-.app-body .status--is-quote .status__info .status__display-name {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info .status__display-name {
     gap: 6px;
 }
 .app-body .status--is-quote .account__avatar {
     width: 22px !important;
     height: 22px !important;
 }
-.app-body .status--is-quote .status__relative-time {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__relative-time {
     inset-inline-end: 10px;
 }
 
@@ -5649,7 +5655,8 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     }
 }
 .app-body .notification-group {
-    padding: 16px 23px;
+    padding: 16px 12px 16px 23px;
+    gap: 0;
 }
 .app-body .notification-group,
 .app-body .notification-ungrouped {
@@ -5723,6 +5730,13 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 .app-body .notification-group__main {
     overflow: unset;
+    padding: 0 10px;
+}
+@media screen and (max-width:770px) {
+    .app-body .notification-group__main {
+        overflow: unset;
+        padding: 0;
+    }
 }
 .app-body .notification-group__main__status {
     border: 1px solid var(--color-content-secondary-bg);
@@ -7483,6 +7497,15 @@ a:is(.active,
 .app-body .rules-list li:last-child {
     border-bottom: 0;
 }
+.app-body .about__section__body .rules-languages label {
+    color: var(--color-content-fg);
+}
+.app-body .about__section__body .rules-languages > select {
+    background: var(--color-accent-bg);
+    color: var(--color-content-fg);
+    border-color: var(--color-accent-lines);
+}
+
 .about__domain-blocks {
     background-color: var(--color-content-bg);
     border: 0;
@@ -8151,4 +8174,88 @@ a:is(.active,
 )::before {
     background-image: var(--icon-olympics);
     transform: scale(1.85);
+}
+
+/* Mastodon 4.5.0 fixes */
+.app-body .status--has-quote .status__content {
+  display: block;
+}
+.app-body .status__quote-author-button {
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+}
+.app-body .notification-ungrouped--quote .status--is-quote .status__avatar,
+.app-body .notification-ungrouped--quote .status--is-quote .account__avatar {
+  width: 16px !important;
+  height: 16px !important;
+}
+.app-body .notification-bar__action {
+  color: var(--color-accent);
+}
+.app-body .notification-bar__action:hover,
+.app-body .notification-bar__action:focus,
+.app-body .notification-bar__action:active
+{
+  background: var(--color-accent-bg);
+}
+.app-body .dialog-modal__header {
+  border-bottom-color: var(--color-lines);
+}
+.app-body .dialog-modal__content__description {
+  color: var(--color-content-fg);
+}
+.app-body .visibility-dropdown__button {
+  background: var(--color-accent-bg);
+  color: var(--color-content-fg);
+  border-color: var(--color-accent-lines);
+}
+.app-body .privacy-dropdown__dropdown,
+.app-body .language-dropdown__dropdown,
+.app-body .visibility-dropdown__dropdown {
+  background: var(--color-content-secondary-bg);
+  border-color: var(--color-content-secondary-separator);
+}
+.app-body .privacy-dropdown__option__content strong,
+.app-body .visibility-dropdown__option__content strong {
+  color: var(--color-content-fg-bold);
+}
+.app-body .privacy-dropdown__option__content,
+.app-body .visibility-dropdown__option__content {
+  color: var(--color-content-fg);
+}
+.app-body .privacy-dropdown__option:focus,
+.app-body .privacy-dropdown__option.active,
+.app-body .visibility-dropdown__option:focus,
+.app-body .visibility-dropdown__option.active {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+.app-body .privacy-dropdown__option:hover,
+.app-body .privacy-dropdown__option:active,
+.app-body .visibility-dropdown__option:hover,
+.app-body .visibility-dropdown__option:active {
+  background: var(--color-accent-focus);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-globe {
+  background-image: var(--icon-globe-visibility-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-unlock {
+  background-image: var(--icon-unlock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-lock {
+  background-image: var(--icon-lock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-at {
+  background-image: var(--icon-at-inv);
+}
+.app-body .compose-form .status__quote {
+  margin-bottom: 8px;
+  border-color: var(--color-accent-lines);
+}
+.app-body .compose-form .status__wrapper {
+  padding: 0;
+}
+.app-body .notification-ungrouped .status:not(.status--is-quote) {
+  border: 0;
+  padding: 0;
 }

--- a/mastodon/app/javascript/styles/tangerineui-lagoon/tangerineui-lagoon.scss
+++ b/mastodon/app/javascript/styles/tangerineui-lagoon/tangerineui-lagoon.scss
@@ -1791,6 +1791,9 @@ body.app-body  {
 .app-body .display-name {
     color: var(--color-content-fg);
 }
+.app-body .compose-form__uploads {
+    margin-bottom: 12px;
+}
 .app-body .compose-form__upload .icon-button.compose-form__upload__delete .icon {
     width: 15px;
     height: 15px;
@@ -1907,6 +1910,9 @@ body.app-body  {
 .app-body .upload-progress .icon {
     color: var(--color-accent)
 }
+.app-body .upload-progress__message {
+    margin-bottom: 20px;
+}
 .app-body .upload-progress__message,
 .app-body .upload-progress__message span {
     color: var(--color-content-fg);
@@ -1946,7 +1952,7 @@ body.app-body  {
     margin-top: 5px;
     padding-inline-start: 12px;
     gap: 6px;
-    margin-bottom: -10px;
+    margin-bottom: 12px;
 }
 .app-body .compose-form__poll__select__label {
     display: none;
@@ -2360,7 +2366,7 @@ body.app-body  {
 .app-body .status__prepend a bdi {
     font-weight: bold;
 }
-.app-body .status {
+.app-body .status:not(.compose-form .status) {
     margin-left: 56px;
     padding: 0 10px;
     border-bottom: 0;
@@ -2400,7 +2406,7 @@ body.app-body  {
 .app-body .dismissable-banner + .scrollable > div > article:first-child > div > .status__wrapper {
     border-top: 0;
 }
-.app-body .status__info {
+.app-body .status__info:not(.compose-form .status__info) {
     height: 22px;
     width: calc(100% + 56px);
     gap: 2px;
@@ -2410,20 +2416,20 @@ body.app-body  {
     line-height: 0.625;
     align-items: start;
 }
-.app-body .status__info .status__display-name {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name {
     overflow: visible;
     align-items: start;
     max-height: 22px;
 }
-.app-body .status__info .status__display-name .display-name bdi,
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name bdi,
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     vertical-align: top;
 }
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     display: inline;
     opacity: .6;
 }
-.app-body .status__relative-time {
+.app-body .status__relative-time:not(.compose-form .status__relative-time) {
     height: 22px;
     color: var(--color-content-fg);
     display: flex;
@@ -2475,7 +2481,7 @@ body.app-body  {
 .app-body .status__relative-time time + abbr {
     order: 2;
 }
-.app-body .status__avatar {
+.app-body .status__avatar:not(.compose-form .status__avatar) {
     margin-bottom: -10px;
     z-index: 2;
     border-radius: 50%;
@@ -3319,7 +3325,7 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 
 /* Quote posts */
-.app-body .status__quote {
+.app-body .status__quote:not(.compose-form .status__quote) {
     margin-inline-start: 0;
     border-radius: 10px;
     border: 1px solid var(--color-lines);
@@ -3341,23 +3347,23 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     border-radius: 10px;
     --color-post-bg: var(--color-content-secondary-bg);
 }
-.app-body .status--is-quote {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) {
     margin-inline-start: 0;
     padding: 0;
     overflow: hidden;
 }
-.app-body .status--is-quote .status__info {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info {
     margin-inline-start: 0;
     margin-block-end: 5px;
 }
-.app-body .status--is-quote .status__info .status__display-name {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info .status__display-name {
     gap: 6px;
 }
 .app-body .status--is-quote .account__avatar {
     width: 22px !important;
     height: 22px !important;
 }
-.app-body .status--is-quote .status__relative-time {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__relative-time {
     inset-inline-end: 10px;
 }
 
@@ -5649,7 +5655,8 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     }
 }
 .app-body .notification-group {
-    padding: 16px 23px;
+    padding: 16px 12px 16px 23px;
+    gap: 0;
 }
 .app-body .notification-group,
 .app-body .notification-ungrouped {
@@ -5723,6 +5730,13 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 .app-body .notification-group__main {
     overflow: unset;
+    padding: 0 10px;
+}
+@media screen and (max-width:770px) {
+    .app-body .notification-group__main {
+        overflow: unset;
+        padding: 0;
+    }
 }
 .app-body .notification-group__main__status {
     border: 1px solid var(--color-content-secondary-bg);
@@ -7483,6 +7497,15 @@ a:is(.active,
 .app-body .rules-list li:last-child {
     border-bottom: 0;
 }
+.app-body .about__section__body .rules-languages label {
+    color: var(--color-content-fg);
+}
+.app-body .about__section__body .rules-languages > select {
+    background: var(--color-accent-bg);
+    color: var(--color-content-fg);
+    border-color: var(--color-accent-lines);
+}
+
 .about__domain-blocks {
     background-color: var(--color-content-bg);
     border: 0;
@@ -8151,4 +8174,88 @@ a:is(.active,
 )::before {
     background-image: var(--icon-olympics);
     transform: scale(1.85);
+}
+
+/* Mastodon 4.5.0 fixes */
+.app-body .status--has-quote .status__content {
+  display: block;
+}
+.app-body .status__quote-author-button {
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+}
+.app-body .notification-ungrouped--quote .status--is-quote .status__avatar,
+.app-body .notification-ungrouped--quote .status--is-quote .account__avatar {
+  width: 16px !important;
+  height: 16px !important;
+}
+.app-body .notification-bar__action {
+  color: var(--color-accent);
+}
+.app-body .notification-bar__action:hover,
+.app-body .notification-bar__action:focus,
+.app-body .notification-bar__action:active
+{
+  background: var(--color-accent-bg);
+}
+.app-body .dialog-modal__header {
+  border-bottom-color: var(--color-lines);
+}
+.app-body .dialog-modal__content__description {
+  color: var(--color-content-fg);
+}
+.app-body .visibility-dropdown__button {
+  background: var(--color-accent-bg);
+  color: var(--color-content-fg);
+  border-color: var(--color-accent-lines);
+}
+.app-body .privacy-dropdown__dropdown,
+.app-body .language-dropdown__dropdown,
+.app-body .visibility-dropdown__dropdown {
+  background: var(--color-content-secondary-bg);
+  border-color: var(--color-content-secondary-separator);
+}
+.app-body .privacy-dropdown__option__content strong,
+.app-body .visibility-dropdown__option__content strong {
+  color: var(--color-content-fg-bold);
+}
+.app-body .privacy-dropdown__option__content,
+.app-body .visibility-dropdown__option__content {
+  color: var(--color-content-fg);
+}
+.app-body .privacy-dropdown__option:focus,
+.app-body .privacy-dropdown__option.active,
+.app-body .visibility-dropdown__option:focus,
+.app-body .visibility-dropdown__option.active {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+.app-body .privacy-dropdown__option:hover,
+.app-body .privacy-dropdown__option:active,
+.app-body .visibility-dropdown__option:hover,
+.app-body .visibility-dropdown__option:active {
+  background: var(--color-accent-focus);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-globe {
+  background-image: var(--icon-globe-visibility-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-unlock {
+  background-image: var(--icon-unlock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-lock {
+  background-image: var(--icon-lock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-at {
+  background-image: var(--icon-at-inv);
+}
+.app-body .compose-form .status__quote {
+  margin-bottom: 8px;
+  border-color: var(--color-accent-lines);
+}
+.app-body .compose-form .status__wrapper {
+  padding: 0;
+}
+.app-body .notification-ungrouped .status:not(.status--is-quote) {
+  border: 0;
+  padding: 0;
 }

--- a/mastodon/app/javascript/styles/tangerineui-purple/tangerineui-purple.scss
+++ b/mastodon/app/javascript/styles/tangerineui-purple/tangerineui-purple.scss
@@ -1791,6 +1791,9 @@ body.app-body  {
 .app-body .display-name {
     color: var(--color-content-fg);
 }
+.app-body .compose-form__uploads {
+    margin-bottom: 12px;
+}
 .app-body .compose-form__upload .icon-button.compose-form__upload__delete .icon {
     width: 15px;
     height: 15px;
@@ -1907,6 +1910,9 @@ body.app-body  {
 .app-body .upload-progress .icon {
     color: var(--color-accent)
 }
+.app-body .upload-progress__message {
+    margin-bottom: 20px;
+}
 .app-body .upload-progress__message,
 .app-body .upload-progress__message span {
     color: var(--color-content-fg);
@@ -1946,7 +1952,7 @@ body.app-body  {
     margin-top: 5px;
     padding-inline-start: 12px;
     gap: 6px;
-    margin-bottom: -10px;
+    margin-bottom: 12px;
 }
 .app-body .compose-form__poll__select__label {
     display: none;
@@ -2360,7 +2366,7 @@ body.app-body  {
 .app-body .status__prepend a bdi {
     font-weight: bold;
 }
-.app-body .status {
+.app-body .status:not(.compose-form .status) {
     margin-left: 56px;
     padding: 0 10px;
     border-bottom: 0;
@@ -2400,7 +2406,7 @@ body.app-body  {
 .app-body .dismissable-banner + .scrollable > div > article:first-child > div > .status__wrapper {
     border-top: 0;
 }
-.app-body .status__info {
+.app-body .status__info:not(.compose-form .status__info) {
     height: 22px;
     width: calc(100% + 56px);
     gap: 2px;
@@ -2410,20 +2416,20 @@ body.app-body  {
     line-height: 0.625;
     align-items: start;
 }
-.app-body .status__info .status__display-name {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name {
     overflow: visible;
     align-items: start;
     max-height: 22px;
 }
-.app-body .status__info .status__display-name .display-name bdi,
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name bdi,
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     vertical-align: top;
 }
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     display: inline;
     opacity: .6;
 }
-.app-body .status__relative-time {
+.app-body .status__relative-time:not(.compose-form .status__relative-time) {
     height: 22px;
     color: var(--color-content-fg);
     display: flex;
@@ -2475,7 +2481,7 @@ body.app-body  {
 .app-body .status__relative-time time + abbr {
     order: 2;
 }
-.app-body .status__avatar {
+.app-body .status__avatar:not(.compose-form .status__avatar) {
     margin-bottom: -10px;
     z-index: 2;
     border-radius: 50%;
@@ -3319,7 +3325,7 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 
 /* Quote posts */
-.app-body .status__quote {
+.app-body .status__quote:not(.compose-form .status__quote) {
     margin-inline-start: 0;
     border-radius: 10px;
     border: 1px solid var(--color-lines);
@@ -3341,23 +3347,23 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     border-radius: 10px;
     --color-post-bg: var(--color-content-secondary-bg);
 }
-.app-body .status--is-quote {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) {
     margin-inline-start: 0;
     padding: 0;
     overflow: hidden;
 }
-.app-body .status--is-quote .status__info {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info {
     margin-inline-start: 0;
     margin-block-end: 5px;
 }
-.app-body .status--is-quote .status__info .status__display-name {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info .status__display-name {
     gap: 6px;
 }
 .app-body .status--is-quote .account__avatar {
     width: 22px !important;
     height: 22px !important;
 }
-.app-body .status--is-quote .status__relative-time {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__relative-time {
     inset-inline-end: 10px;
 }
 
@@ -5649,7 +5655,8 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     }
 }
 .app-body .notification-group {
-    padding: 16px 23px;
+    padding: 16px 12px 16px 23px;
+    gap: 0;
 }
 .app-body .notification-group,
 .app-body .notification-ungrouped {
@@ -5723,6 +5730,13 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 .app-body .notification-group__main {
     overflow: unset;
+    padding: 0 10px;
+}
+@media screen and (max-width:770px) {
+    .app-body .notification-group__main {
+        overflow: unset;
+        padding: 0;
+    }
 }
 .app-body .notification-group__main__status {
     border: 1px solid var(--color-content-secondary-bg);
@@ -7483,6 +7497,15 @@ a:is(.active,
 .app-body .rules-list li:last-child {
     border-bottom: 0;
 }
+.app-body .about__section__body .rules-languages label {
+    color: var(--color-content-fg);
+}
+.app-body .about__section__body .rules-languages > select {
+    background: var(--color-accent-bg);
+    color: var(--color-content-fg);
+    border-color: var(--color-accent-lines);
+}
+
 .about__domain-blocks {
     background-color: var(--color-content-bg);
     border: 0;
@@ -8151,4 +8174,88 @@ a:is(.active,
 )::before {
     background-image: var(--icon-olympics);
     transform: scale(1.85);
+}
+
+/* Mastodon 4.5.0 fixes */
+.app-body .status--has-quote .status__content {
+  display: block;
+}
+.app-body .status__quote-author-button {
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+}
+.app-body .notification-ungrouped--quote .status--is-quote .status__avatar,
+.app-body .notification-ungrouped--quote .status--is-quote .account__avatar {
+  width: 16px !important;
+  height: 16px !important;
+}
+.app-body .notification-bar__action {
+  color: var(--color-accent);
+}
+.app-body .notification-bar__action:hover,
+.app-body .notification-bar__action:focus,
+.app-body .notification-bar__action:active
+{
+  background: var(--color-accent-bg);
+}
+.app-body .dialog-modal__header {
+  border-bottom-color: var(--color-lines);
+}
+.app-body .dialog-modal__content__description {
+  color: var(--color-content-fg);
+}
+.app-body .visibility-dropdown__button {
+  background: var(--color-accent-bg);
+  color: var(--color-content-fg);
+  border-color: var(--color-accent-lines);
+}
+.app-body .privacy-dropdown__dropdown,
+.app-body .language-dropdown__dropdown,
+.app-body .visibility-dropdown__dropdown {
+  background: var(--color-content-secondary-bg);
+  border-color: var(--color-content-secondary-separator);
+}
+.app-body .privacy-dropdown__option__content strong,
+.app-body .visibility-dropdown__option__content strong {
+  color: var(--color-content-fg-bold);
+}
+.app-body .privacy-dropdown__option__content,
+.app-body .visibility-dropdown__option__content {
+  color: var(--color-content-fg);
+}
+.app-body .privacy-dropdown__option:focus,
+.app-body .privacy-dropdown__option.active,
+.app-body .visibility-dropdown__option:focus,
+.app-body .visibility-dropdown__option.active {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+.app-body .privacy-dropdown__option:hover,
+.app-body .privacy-dropdown__option:active,
+.app-body .visibility-dropdown__option:hover,
+.app-body .visibility-dropdown__option:active {
+  background: var(--color-accent-focus);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-globe {
+  background-image: var(--icon-globe-visibility-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-unlock {
+  background-image: var(--icon-unlock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-lock {
+  background-image: var(--icon-lock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-at {
+  background-image: var(--icon-at-inv);
+}
+.app-body .compose-form .status__quote {
+  margin-bottom: 8px;
+  border-color: var(--color-accent-lines);
+}
+.app-body .compose-form .status__wrapper {
+  padding: 0;
+}
+.app-body .notification-ungrouped .status:not(.status--is-quote) {
+  border: 0;
+  padding: 0;
 }

--- a/mastodon/app/javascript/styles/tangerineui/tangerineui.scss
+++ b/mastodon/app/javascript/styles/tangerineui/tangerineui.scss
@@ -1791,6 +1791,9 @@ body.app-body  {
 .app-body .display-name {
     color: var(--color-content-fg);
 }
+.app-body .compose-form__uploads {
+    margin-bottom: 12px;
+}
 .app-body .compose-form__upload .icon-button.compose-form__upload__delete .icon {
     width: 15px;
     height: 15px;
@@ -1907,6 +1910,9 @@ body.app-body  {
 .app-body .upload-progress .icon {
     color: var(--color-accent)
 }
+.app-body .upload-progress__message {
+    margin-bottom: 20px;
+}
 .app-body .upload-progress__message,
 .app-body .upload-progress__message span {
     color: var(--color-content-fg);
@@ -1946,7 +1952,7 @@ body.app-body  {
     margin-top: 5px;
     padding-inline-start: 12px;
     gap: 6px;
-    margin-bottom: -10px;
+    margin-bottom: 12px;
 }
 .app-body .compose-form__poll__select__label {
     display: none;
@@ -2360,7 +2366,7 @@ body.app-body  {
 .app-body .status__prepend a bdi {
     font-weight: bold;
 }
-.app-body .status {
+.app-body .status:not(.compose-form .status) {
     margin-left: 56px;
     padding: 0 10px;
     border-bottom: 0;
@@ -2400,7 +2406,7 @@ body.app-body  {
 .app-body .dismissable-banner + .scrollable > div > article:first-child > div > .status__wrapper {
     border-top: 0;
 }
-.app-body .status__info {
+.app-body .status__info:not(.compose-form .status__info) {
     height: 22px;
     width: calc(100% + 56px);
     gap: 2px;
@@ -2410,20 +2416,20 @@ body.app-body  {
     line-height: 0.625;
     align-items: start;
 }
-.app-body .status__info .status__display-name {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name {
     overflow: visible;
     align-items: start;
     max-height: 22px;
 }
-.app-body .status__info .status__display-name .display-name bdi,
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name bdi,
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     vertical-align: top;
 }
-.app-body .status__info .status__display-name .display-name__account {
+.app-body .status__info:not(.compose-form .status__info) .status__display-name .display-name__account {
     display: inline;
     opacity: .6;
 }
-.app-body .status__relative-time {
+.app-body .status__relative-time:not(.compose-form .status__relative-time) {
     height: 22px;
     color: var(--color-content-fg);
     display: flex;
@@ -2475,7 +2481,7 @@ body.app-body  {
 .app-body .status__relative-time time + abbr {
     order: 2;
 }
-.app-body .status__avatar {
+.app-body .status__avatar:not(.compose-form .status__avatar) {
     margin-bottom: -10px;
     z-index: 2;
     border-radius: 50%;
@@ -3319,7 +3325,7 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 
 /* Quote posts */
-.app-body .status__quote {
+.app-body .status__quote:not(.compose-form .status__quote) {
     margin-inline-start: 0;
     border-radius: 10px;
     border: 1px solid var(--color-lines);
@@ -3341,23 +3347,23 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     border-radius: 10px;
     --color-post-bg: var(--color-content-secondary-bg);
 }
-.app-body .status--is-quote {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) {
     margin-inline-start: 0;
     padding: 0;
     overflow: hidden;
 }
-.app-body .status--is-quote .status__info {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info {
     margin-inline-start: 0;
     margin-block-end: 5px;
 }
-.app-body .status--is-quote .status__info .status__display-name {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__info .status__display-name {
     gap: 6px;
 }
 .app-body .status--is-quote .account__avatar {
     width: 22px !important;
     height: 22px !important;
 }
-.app-body .status--is-quote .status__relative-time {
+.app-body .status--is-quote:not(.compose-form .status--is-quote) .status__relative-time {
     inset-inline-end: 10px;
 }
 
@@ -5649,7 +5655,8 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
     }
 }
 .app-body .notification-group {
-    padding: 16px 23px;
+    padding: 16px 12px 16px 23px;
+    gap: 0;
 }
 .app-body .notification-group,
 .app-body .notification-ungrouped {
@@ -5723,6 +5730,13 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
 }
 .app-body .notification-group__main {
     overflow: unset;
+    padding: 0 10px;
+}
+@media screen and (max-width:770px) {
+    .app-body .notification-group__main {
+        overflow: unset;
+        padding: 0;
+    }
 }
 .app-body .notification-group__main__status {
     border: 1px solid var(--color-content-secondary-bg);
@@ -7483,6 +7497,15 @@ a:is(.active,
 .app-body .rules-list li:last-child {
     border-bottom: 0;
 }
+.app-body .about__section__body .rules-languages label {
+    color: var(--color-content-fg);
+}
+.app-body .about__section__body .rules-languages > select {
+    background: var(--color-accent-bg);
+    color: var(--color-content-fg);
+    border-color: var(--color-accent-lines);
+}
+
 .about__domain-blocks {
     background-color: var(--color-content-bg);
     border: 0;
@@ -8151,4 +8174,88 @@ a:is(.active,
 )::before {
     background-image: var(--icon-olympics);
     transform: scale(1.85);
+}
+
+/* Mastodon 4.5.0 fixes */
+.app-body .status--has-quote .status__content {
+  display: block;
+}
+.app-body .status__quote-author-button {
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+}
+.app-body .notification-ungrouped--quote .status--is-quote .status__avatar,
+.app-body .notification-ungrouped--quote .status--is-quote .account__avatar {
+  width: 16px !important;
+  height: 16px !important;
+}
+.app-body .notification-bar__action {
+  color: var(--color-accent);
+}
+.app-body .notification-bar__action:hover,
+.app-body .notification-bar__action:focus,
+.app-body .notification-bar__action:active
+{
+  background: var(--color-accent-bg);
+}
+.app-body .dialog-modal__header {
+  border-bottom-color: var(--color-lines);
+}
+.app-body .dialog-modal__content__description {
+  color: var(--color-content-fg);
+}
+.app-body .visibility-dropdown__button {
+  background: var(--color-accent-bg);
+  color: var(--color-content-fg);
+  border-color: var(--color-accent-lines);
+}
+.app-body .privacy-dropdown__dropdown,
+.app-body .language-dropdown__dropdown,
+.app-body .visibility-dropdown__dropdown {
+  background: var(--color-content-secondary-bg);
+  border-color: var(--color-content-secondary-separator);
+}
+.app-body .privacy-dropdown__option__content strong,
+.app-body .visibility-dropdown__option__content strong {
+  color: var(--color-content-fg-bold);
+}
+.app-body .privacy-dropdown__option__content,
+.app-body .visibility-dropdown__option__content {
+  color: var(--color-content-fg);
+}
+.app-body .privacy-dropdown__option:focus,
+.app-body .privacy-dropdown__option.active,
+.app-body .visibility-dropdown__option:focus,
+.app-body .visibility-dropdown__option.active {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+.app-body .privacy-dropdown__option:hover,
+.app-body .privacy-dropdown__option:active,
+.app-body .visibility-dropdown__option:hover,
+.app-body .visibility-dropdown__option:active {
+  background: var(--color-accent-focus);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-globe {
+  background-image: var(--icon-globe-visibility-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-unlock {
+  background-image: var(--icon-unlock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-lock {
+  background-image: var(--icon-lock-inv);
+}
+.app-body .visibility-dropdown__option:is(:active, .active) .icon-at {
+  background-image: var(--icon-at-inv);
+}
+.app-body .compose-form .status__quote {
+  margin-bottom: 8px;
+  border-color: var(--color-accent-lines);
+}
+.app-body .compose-form .status__wrapper {
+  padding: 0;
+}
+.app-body .notification-ungrouped .status:not(.status--is-quote) {
+  border: 0;
+  padding: 0;
 }


### PR DESCRIPTION
I've been running a custom variant for my instance (thecanadian.social), and I've added some fixes to make quote posts work correctly with TangerineUI. I figured I'd backport them to the official variants and submit a PR for ya!

Some screens:
<img width="1848" height="1487" alt="Screenshot_20251018_234411" src="https://github.com/user-attachments/assets/ff6fb1d0-e6d9-4645-9f09-bf0ec1fd432e" />
<img width="1842" height="1491" alt="Screenshot_20251018_234229" src="https://github.com/user-attachments/assets/47557dbc-9ae3-4be6-93c1-c4a63a9fee8b" />
<img width="1829" height="1504" alt="Screenshot_20251018_234158" src="https://github.com/user-attachments/assets/15d3eb61-4bdc-487e-a394-c29f2f9c07a9" />
<img width="1875" height="1508" alt="Screenshot_20251018_234126" src="https://github.com/user-attachments/assets/010fe2c4-6e70-4902-9b28-0c09c1a5793c" />

There's a bunch of fixes for the notifications & visibility modal as well.
<img width="877" height="556" alt="image" src="https://github.com/user-attachments/assets/75f1b74c-61e9-43b4-86d4-fb7a2a222f1a" />
<img width="950" height="728" alt="Screenshot_20251019_001359" src="https://github.com/user-attachments/assets/80e04870-8091-487d-8849-ad4a8edf664a" />

Here's a bonus screen for the `Maple` variant I hacked up for my instance:
<img width="1827" height="1496" alt="Screenshot_20251018_234605" src="https://github.com/user-attachments/assets/229b6657-5224-451b-8e87-9618062e6529" />

If anyone is interested here's the [maple variant](https://git.sr.ht/~quaff/tangerineui-maple).